### PR TITLE
I remove the break after the regex match - since in Huawei the config …

### DIFF
--- a/cloudshell/cli/session/expect_session.py
+++ b/cloudshell/cli/session/expect_session.py
@@ -125,7 +125,7 @@ class ExpectSession(Session):
             if re.search(re_string, output_str, re.DOTALL):
                 output_list.append(output_str)
                 is_correct_exit = True
-                break
+
 
             for expect_string in expect_map:
                 result_match = re.search(expect_string, output_str, re.DOTALL)
@@ -138,6 +138,7 @@ class ExpectSession(Session):
                     output_str = ''
                     is_matched = True
                     break
+            if(is_correct_exit):break
             if not is_matched:
                 time.sleep(self._empty_loop_timeout)
 


### PR DESCRIPTION
…mode prompt contains [] the same as in [Y/N] . So in some casses when it should match [Y/N] it matched the prompt and break  []

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-cli/20)
<!-- Reviewable:end -->
