### PR TITLE
Command retries parameter

### DIFF
--- a/cloudshell/cli/service/cli_service.py
+++ b/cloudshell/cli/service/cli_service.py
@@ -87,7 +87,7 @@ class CliService(CliServiceInterface):
 
     @inject.params(logger=LOGGER)
     def _send_command(self, command, expected_str=None, expected_map=None, error_map=None, logger=None, session=None,
-                      is_need_default_prompt=True, **optional_args):
+                      is_need_default_prompt=True, command_retries=None, **optional_args):
         """Send command
 
         :param command: command to send
@@ -108,12 +108,12 @@ class CliService(CliServiceInterface):
             if is_need_default_prompt:
                 expected_str = expected_str + '|' + self._prompt
 
-        command_retries = self._command_retries
-        if 'command_retries' in optional_args:
-            command_retries = optional_args['command_retries']
+        command_retries_count = self._command_retries
+        if command_retries:
+            command_retries_count = command_retries
 
         out = ''
-        for retry in range(command_retries):
+        for retry in range(command_retries_count):
             try:
                 out = session.hardware_expect(command, expected_str, expect_map=expected_map, error_map=error_map,
                                               **optional_args)

--- a/cloudshell/cli/service/cli_service.py
+++ b/cloudshell/cli/service/cli_service.py
@@ -107,8 +107,12 @@ class CliService(CliServiceInterface):
             if is_need_default_prompt:
                 expected_str = expected_str + '|' + self._prompt
 
+        command_retries = self._command_retries
+        if 'command_retries' in optional_args:
+            command_retries = optional_args['command_retries']
+
         out = ''
-        for retry in range(self._command_retries):
+        for retry in range(command_retries):
             try:
                 out = session.hardware_expect(command, expected_str, expect_map=expected_map, error_map=error_map,
                                               **optional_args)
@@ -117,7 +121,7 @@ class CliService(CliServiceInterface):
                 raise command_error
             except Exception as e:
                 logger.error(e)
-                if retry == self._command_retries - 1:
+                if retry == command_retries - 1:
                     logger.error(traceback.format_exc())
                     raise Exception('Failed to send command')
                 session.reconnect(self._prompt)


### PR DESCRIPTION
Added incoming parameter in scope of kwargs arguments named 'command_retries' to override default self._command_retries parameter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-cli/31)
<!-- Reviewable:end -->
